### PR TITLE
Feature/use maps for errors

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -93,6 +93,17 @@ func (ce *HTTPError) MarshalJSON() ([]byte, error) {
 // ServerHTTP is our custom implementation needed to satisfy the Handler
 // interface.
 func (ch CustomHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if origin := req.Header.Get("Origin"); origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers",
+			"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	}
+
+	if req.Method == "OPTIONS" {
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 
 	if err := ch(w, req); err != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -10,13 +10,12 @@ import (
 // CustomHandler it our Handler func enhanced to early return errors.
 type CustomHandler func(http.ResponseWriter, *http.Request) *HTTPError
 
-// HTTPError struct implements the Error interface to make easier return HTTP
-// errors. Using this HTTPError we are able to return the error plus the HTTP
-// Status Code that we want the middleware to return on the request.
+// HTTPError struct implements the Error interface to enable early return HTTP
+// errors.
 //
 // Using an interface{} might be a little weird, this interface will receive
-// error or []error, the interface{} was created to make the HTTPError simpler
-// to use.
+// error or map[string]string, the interface{} was created to make the
+// HTTPError simpler to use.
 //
 // Examples:
 //
@@ -24,20 +23,23 @@ type CustomHandler func(http.ResponseWriter, *http.Request) *HTTPError
 // &handler.HTTPError{err, http.StatusInternalServerError}
 //
 // - Error array
-// for _, err := range result.Errors() {
-//	errors = append(errors, fmt.Errorf("%s", err))
-// }
+// var reqErrors = make(map[string]string)
+//
+// reqErrors["_error"] = "Unable to do that"
+// reqErrors["code"] = "Code can not be null"
+//
 // return &handler.HTTPError{errors, http.StatusBadRequest}
 //
 // Used this approach to create this kind of errors:
 // {
-//   "errors": [
-//	 	 "Non valid Snapshot sent.",
-//		 "card_3: String length must be greater than or equal to 3",
-//		 "card_7: String length must be greater than or equal to 3"
-//	 ],
-//	 "status_code": 400
+//   "errors": {
+//     "_error": "Non valid Snapshot sent",
+//     "cups": "Must be greater than or equal to 1",
+//     "wins": "Must be greater than or equal to 1"
+//   },
+//   "status_code": 400
 // }
+//
 type HTTPError struct {
 	Err        interface{} `json:"error"`
 	StatusCode int         `json:"status_code"`
@@ -50,40 +52,41 @@ func (ce *HTTPError) Error() string {
 	switch v := ce.Err.(type) {
 	case error:
 		errString = v.Error()
-	case []error:
-		for _, err := range v {
-			errString = fmt.Sprint(errString, " ", err)
+	case map[string]string:
+		for key, err := range v {
+			errString = fmt.Sprint(errString, " ", key, " ", err)
 		}
 	}
 
 	return errString
 }
 
-// MarshalJSON implementation needed to change the default Marshall behaviour
-// with errors.
+// MarshalJSON implementation needed to change the default marshalling
+// error's behaviour.
 //
-// Errors won't get Marshalled by themselves, this behaviour occurs because in
-// order to be able to Marshal errors the error package would have to to import
-// the encoding/json package, creating a import cycle as obviously the
-// encoding/json uses errors.
+// Errors won't get marshalled, this behaviour happens because in order to do
+// that the error package would have to to import the encoding/json one, by
+// doing so a import cycle will happen as the encoding/json package
+// use errors.
 //
 // You can find more information on the following issue:
 // https://github.com/golang/go/issues/10748
+//
+// If the maps[string]string error format is used then it just throw it to the
+// json.Marshl func.
 func (ce *HTTPError) MarshalJSON() ([]byte, error) {
-	var errors []string
+	var errors map[string]string
 
 	switch v := ce.Err.(type) {
 	case error:
-		errors = append(errors, v.Error())
-	case []error:
-		for _, err := range v {
-			errors = append(errors, err.Error())
-		}
+		errors["_error"] = v.Error()
+	case map[string]string:
+		errors = v
 	}
 
 	return json.Marshal(&struct {
-		Errors     []string `json:"errors"`
-		StatusCode int      `json:"status_code"`
+		Errors     map[string]string `json:"errors"`
+		StatusCode int               `json:"status_code"`
 	}{
 		Errors:     errors,
 		StatusCode: ce.StatusCode,
@@ -109,14 +112,12 @@ func (ch CustomHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err := ch(w, req); err != nil {
 		log.Println(err)
 
-		w.WriteHeader(err.StatusCode)
-
-		jsonErr, err := json.Marshal(err)
-		if err != nil {
-			log.Println("Error while Marshaling the HTTPError: ", err)
-			return
+		jsonErr, errMarshal := json.Marshal(err)
+		if errMarshal != nil {
+			http.Error(w, "Unable to return error info, just the status code", err.StatusCode)
 		}
 
+		w.WriteHeader(err.StatusCode)
 		w.Write(jsonErr)
 	}
 }


### PR DESCRIPTION
Not very happy with this implementation but it makes easy for the apps to return multiple errors like:

```json
{
  "errors": {
    "_error": "Non valid Snapshot sent",
    "cups": "Must be greater than or equal to 1",
    "wins": "Must be greater than or equal to 1"
  },
  "status_code": 500
}
```