### PR TITLE
Remove CORS custom Middleware

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -6,14 +6,14 @@ import (
 	"net/http"
 )
 
-// CustomHandler it our Handler func enhanced to early return errors.
-type CustomHandler func(http.ResponseWriter, *http.Request) *Errors
+// Handler it our Handler func enhanced to early return errors.
+type Handler func(http.ResponseWriter, *http.Request) *Errors
 
 // WithLog is the primary custom middleware, it has logging responsibility for
-// request's errors, but also converts the CustomHandler to a http.Handler.
+// request's errors, but also converts the Handler to a http.Handler.
 //
 // Returns a http.Handler ready to be added to the touter.
-func (fn CustomHandler) WithLog() http.Handler {
+func (fn Handler) WithLog() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -25,25 +25,5 @@ func (fn CustomHandler) WithLog() http.Handler {
 				defer log.Println("Unable to write the JSON error response")
 			}
 		}
-	})
-}
-
-// WithCORS is a HTTP middleware to enable CORS on the given handler.
-//
-// Returns a CustomHandler with CORS enabled.
-func (fn CustomHandler) WithCORS() CustomHandler {
-	return CustomHandler(func(w http.ResponseWriter, r *http.Request) *Errors {
-		requestHeaders := r.Header.Get("Access-Control-Request-Headers")
-
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, PUT, DELETE, GET, OPTIONS")
-		w.Header().Set("Access-Control-Request-Method", "*")
-		w.Header().Set("Access-Control-Allow-Headers", requestHeaders)
-
-		if r.Method != "OPTIONS" {
-			return fn(w, r)
-		}
-
-		return nil
 	})
 }


### PR DESCRIPTION
This commit removes the CORS custom Middleware, as if we need to configure CORS again I think that we would be using something better than the custom implementation that we are using here.

This PR also changes the Handler name from `CustomHandler` to `Handler` as the package is under my GitHub account it would be  `jcleira/handler`